### PR TITLE
fixing remove button behaviour in Authentication settings

### DIFF
--- a/src/Firewall/Panel/BaseController.php
+++ b/src/Firewall/Panel/BaseController.php
@@ -496,7 +496,7 @@ class BaseController
         $postParams = (array) get_request()->getParsedBody();
 
         foreach ($fields as $field) {
-            if (empty($postParams[$field])) {
+            if (empty($postParams[$field]) && @!is_numeric($postParams[$field])) {
                 return false;
             }
         }

--- a/src/Firewall/Panel/Security.php
+++ b/src/Firewall/Panel/Security.php
@@ -62,7 +62,7 @@ class Security extends BaseController
     {
         $postParams = get_request()->getParsedBody();
 
-        if ($this->checkPostParamsExist('url', 'user', 'pass', 'action')) {
+        if ($this->checkPostParamsExist('action', 'submit')) {
 
             $url = $postParams['url'];
             $user = $postParams['user'];


### PR DESCRIPTION
On "authentication settings" page (/firewall/panel/security/authentication/) entries can not be removed.
The POST params check fails, because following attributes are empty:

- url
- user
- pass

Also the `checkPostParamsExist` function will fail if the value to be checked is "0" or 0 regarding php documentation:

> The following values are considered to be empty:
>
> "" (an empty string)
> 0 (0 as an integer)
> 0.0 (0 as a float)
> "0" (0 as a string)
> ...

From https://www.php.net/manual/en/function.empty.php