### PR TITLE
Update SetupTrait.php

### DIFF
--- a/src/Firewall/Firewall/SetupTrait.php
+++ b/src/Firewall/Firewall/SetupTrait.php
@@ -313,8 +313,10 @@ trait SetupTrait
         $deniedList = [];
 
         foreach ($ipList as $ip) {
+            if (empty($ip))
+                continue;
 
-            if (0 === strpos($this->kernel->getCurrentUrl(), $ip['url']) ) {
+            if (0 === strpos($this->kernel->getCurrentUrl(), empty($ip['url']) ? '/' : $ip['url']) ) {
 
                 if ('allow' === $ip['rule']) {
                     $allowedList[] = $ip['ip'];


### PR DESCRIPTION
Prevents issues like that when you don't have any rule saved in IP Manager:

**Notice**: Trying to access array offset on value of type bool in /var/www/html/vuln/vendor/shieldon/shieldon/src/Firewall/Firewall/SetupTrait.php on line 317

**Deprecated**: strpos(): Non-string needles will be interpreted as strings in the future. Use an explicit chr() call to preserve the current behavior in /var/www/html/vuln/vendor/shieldon/shieldon/src/Firewall/Firewall/SetupTrait.php on line 317

And, as the URL rule can be empty, the change at 319 line prevents this error:

**Warning**: strpos(): Empty needle in /var/www/html/vuln/vendor/shieldon/shieldon/src/Firewall/Firewall/SetupTrait.php on line 318