### PR TITLE
Make redis driver usable with websockets.

### DIFF
--- a/src/Firewall/Firewall/Driver/ItemRedisDriver.php
+++ b/src/Firewall/Firewall/Driver/ItemRedisDriver.php
@@ -57,7 +57,11 @@ class ItemRedisDriver
 
             // Create a Redis instance.
             $redis = new Redis();
-            $redis->connect($host, $port);
+            if (empty($setting['port'])) {
+                $redis->connect($host);
+            } else {
+                $redis->connect($host, $port);
+            }
 
             if (!empty($setting['auth'])) {
                 // @codeCoverageIgnoreStart


### PR DESCRIPTION
When redis is used via websockets, you must not provide a port number.